### PR TITLE
Remove deprecated "retention_policy".

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ module "kv_diag" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
 
 ## Modules
 

--- a/acr.tf
+++ b/acr.tf
@@ -6,29 +6,14 @@ resource "azurerm_monitor_diagnostic_setting" "acr_diag" {
 
   enabled_log {
     category = "ContainerRegistryLoginEvents"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   # Not needed for compliance
   enabled_log {
     category = "ContainerRegistryRepositoryEvents"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }

--- a/agw.tf
+++ b/agw.tf
@@ -6,36 +6,16 @@ resource "azurerm_monitor_diagnostic_setting" "agw_diag" {
 
   enabled_log {
     category = "ApplicationGatewayAccessLog"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "ApplicationGatewayFirewallLog"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "ApplicationGatewayPerformanceLog"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }

--- a/aks.tf
+++ b/aks.tf
@@ -6,100 +6,40 @@ resource "azurerm_monitor_diagnostic_setting" "aks_diag" {
 
   enabled_log {
     category = "cloud-controller-manager"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "cluster-autoscaler"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "csi-azuredisk-controller"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "csi-azurefile-controller"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "csi-snapshot-controller"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "guard"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "kube-apiserver"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "kube-audit"
-
-    retention_policy {
-      enabled = true
-      days    = 0
-    }
   }
   enabled_log {
     category = "kube-audit-admin"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "kube-controller-manager"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "kube-scheduler"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/app_service.tf
+++ b/app_service.tf
@@ -6,83 +6,38 @@ resource "azurerm_monitor_diagnostic_setting" "asp_diag" {
 
   enabled_log {
     category = "AppServiceAntivirusScanAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceAppLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceConsoleLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceFileAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceHTTPLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceIPSecAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServicePlatformLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/ase.tf
+++ b/ase.tf
@@ -6,20 +6,10 @@ resource "azurerm_monitor_diagnostic_setting" "ase_diag" {
 
   enabled_log {
     category = "AppServiceEnvironmentPlatformLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/automation_account.tf
+++ b/automation_account.tf
@@ -6,47 +6,21 @@ resource "azurerm_monitor_diagnostic_setting" "aa_diag" {
 
   enabled_log {
     category = "AuditEvent"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "DscNodeStatus"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "JobLogs"
 
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "JobStreams"
 
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }

--- a/avd_hostpool.tf
+++ b/avd_hostpool.tf
@@ -6,21 +6,9 @@ resource "azurerm_monitor_diagnostic_setting" "avd_hostpool_diag" {
 
   enabled_log {
     category = "Checkpoint"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Error"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Management"
@@ -34,47 +22,17 @@ resource "azurerm_monitor_diagnostic_setting" "avd_hostpool_diag" {
   }
   enabled_log {
     category = "Connection"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "HostRegistration"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AgentHealthStatus"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "SessionHostManagement"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "NetworkData"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/avd_workspace.tf
+++ b/avd_workspace.tf
@@ -6,38 +6,14 @@ resource "azurerm_monitor_diagnostic_setting" "avd_workspace_diag" {
 
   enabled_log {
     category = "Checkpoint"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Error"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Management"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Feed"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/backup_vault.tf
+++ b/backup_vault.tf
@@ -12,129 +12,45 @@ resource "azurerm_monitor_diagnostic_setting" "rsv_backup_diag" {
 
   enabled_log {
     category = "AddonAzureBackupAlerts"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AddonAzureBackupJobs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AddonAzureBackupPolicy"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AddonAzureBackupProtectedInstance"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AddonAzureBackupStorage"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureBackupReport"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryEvents"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryJobs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryProtectedDiskDataChurn"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryRecoveryPoints"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryReplicatedItems"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryReplicationDataUploadRate"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryReplicationStats"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "CoreAzureBackup"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }
 
@@ -146,129 +62,45 @@ resource "azurerm_monitor_diagnostic_setting" "rsv_site_recovery_diag" {
 
   enabled_log {
     category = "AddonAzureBackupAlerts"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AddonAzureBackupJobs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AddonAzureBackupPolicy"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AddonAzureBackupProtectedInstance"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AddonAzureBackupStorage"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "AzureBackupReport"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryEvents"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryJobs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryProtectedDiskDataChurn"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryRecoveryPoints"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryReplicatedItems"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryReplicationDataUploadRate"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AzureSiteRecoveryReplicationStats"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-
-    }
   }
   enabled_log {
     category = "CoreAzureBackup"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   depends_on = [

--- a/cosmos.tf
+++ b/cosmos.tf
@@ -7,93 +7,33 @@ resource "azurerm_monitor_diagnostic_setting" "cdb_diag" {
 
   enabled_log {
     category = "CassandraRequests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "ControlPlaneRequests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "DataPlaneRequests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "GremlinRequests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "MongoRequests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "PartitionKeyRUConsumption"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "PartitionKeyStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "QueryRuntimeStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "TableApiRequests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "Requests"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/data_factory.tf
+++ b/data_factory.tf
@@ -6,100 +6,45 @@ resource "azurerm_monitor_diagnostic_setting" "df_diag" {
 
   enabled_log {
     category = "ActivityRuns"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "PipelineRuns"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SandboxActivityRuns"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SandboxPipelineRuns"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SSISIntegrationRuntimeLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SSISPackageEventMessageContext"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SSISPackageEventMessages"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SSISPackageExecutableStatistics"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SSISPackageExecutionComponentPhases"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SSISPackageExecutionDataStatistics"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "TriggerRuns"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/databricks.tf
+++ b/databricks.tf
@@ -6,226 +6,101 @@ resource "azurerm_monitor_diagnostic_setting" "dbk_diag" {
 
   enabled_log {
     category = "RemoteHistoryService"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "accounts"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "clusters"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "databrickssql"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "dbfs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "deltaPipelines"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "featureStore"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "genie"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "globalInitScripts"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "iamRole"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "instancePools"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "jobs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "mlflowAcledArtifact"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "mlflowExperiment"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "modelRegistry"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "notebook"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "repos"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "secrets"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "sqlPermissions"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "sqlanalytics"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "ssh"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "unityCatalog"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "workspace"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "gitCredentials"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "webTerminal"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/eventhub.tf
+++ b/eventhub.tf
@@ -6,93 +6,34 @@ resource "azurerm_monitor_diagnostic_setting" "eh_diag" {
 
   enabled_log {
     category = "ApplicationMetricsLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "RuntimeAuditLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "ArchiveLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "AutoScaleLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "CustomerManagedKeyUserLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "EventHubVNetConnectionEvent"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "KafkaCoordinatorLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "KafkaUserErrorLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "OperationalLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/functions.tf
+++ b/functions.tf
@@ -6,21 +6,10 @@ resource "azurerm_monitor_diagnostic_setting" "func_diag" {
 
   enabled_log {
     category = "FunctionAppLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/fw.tf
+++ b/fw.tf
@@ -6,41 +6,17 @@ resource "azurerm_monitor_diagnostic_setting" "fw_diag" {
 
   enabled_log {
     category = "AzureFirewallApplicationRule"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AzureFirewallNetworkRule"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AzureFirewallDnsProxy"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/keyvault.tf
+++ b/keyvault.tf
@@ -6,31 +6,13 @@ resource "azurerm_monitor_diagnostic_setting" "kv_diag" {
 
   enabled_log {
     category = "AuditEvent"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AzurePolicyEvaluationDetails"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/kusto.tf
+++ b/kusto.tf
@@ -6,83 +6,38 @@ resource "azurerm_monitor_diagnostic_setting" "kusto_diag" {
 
   enabled_log {
     category = "Command"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "FailedIngestion"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "IngestionBatching"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "Journal"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "Query"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SucceededIngestion"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "TableDetails"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "TableUsageStatistics"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/law.tf
+++ b/law.tf
@@ -6,20 +6,10 @@ resource "azurerm_monitor_diagnostic_setting" "law_diag" {
 
   enabled_log {
     category = "Audit"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }

--- a/lb.tf
+++ b/lb.tf
@@ -6,11 +6,5 @@ resource "azurerm_monitor_diagnostic_setting" "lb_diag" {
 
   metric {
     category = "AllMetrics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/logicapp.tf
+++ b/logicapp.tf
@@ -6,29 +6,14 @@ resource "azurerm_monitor_diagnostic_setting" "logicapp_diag" {
 
   enabled_log {
     category = "FunctionAppLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "WorkflowRuntime"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/mssql.tf
+++ b/mssql.tf
@@ -8,11 +8,6 @@ resource "azurerm_monitor_diagnostic_setting" "mssql_diag" {
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }
 

--- a/mssql_db.tf
+++ b/mssql_db.tf
@@ -6,130 +6,60 @@ resource "azurerm_monitor_diagnostic_setting" "mssql_db_diag" {
 
   enabled_log {
     category = "DevOpsOperationsAudit"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SQLSecurityAuditEvents"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "SQLInsights"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   enabled_log {
     category = "AutomaticTuning"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   enabled_log {
     category = "QueryStoreRuntimeStatistics"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   enabled_log {
     category = "QueryStoreWaitStatistics"
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   enabled_log {
     category = "Errors"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "DatabaseWaitStatistics"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "Timeouts"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "Blocks"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "Deadlocks"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "Basic"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "InstanceAndAppAdvanced"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "WorkloadManagement"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }
 

--- a/mssql_ep.tf
+++ b/mssql_ep.tf
@@ -7,20 +7,10 @@ resource "azurerm_monitor_diagnostic_setting" "mssql_ep_diag" {
   metric {
     category = "Basic"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "InstanceAndAppAdvanced"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/mysql.tf
+++ b/mysql.tf
@@ -6,30 +6,12 @@ resource "azurerm_monitor_diagnostic_setting" "msql_diag" {
 
   enabled_log {
     category = "MySqlAuditLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "MySqlSlowLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/nsg.tf
+++ b/nsg.tf
@@ -6,20 +6,8 @@ resource "azurerm_monitor_diagnostic_setting" "nsg_diag" {
 
   enabled_log {
     category = "NetworkSecurityGroupEvent"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "NetworkSecurityGroupRuleCounter"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/psql.tf
+++ b/psql.tf
@@ -6,39 +6,16 @@ resource "azurerm_monitor_diagnostic_setting" "psql_diag" {
 
   enabled_log {
     category = "PostgreSQLLogs"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "QueryStoreRuntimeStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "QueryStoreWaitStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/redis.tf
+++ b/redis.tf
@@ -6,21 +6,9 @@ resource "azurerm_monitor_diagnostic_setting" "rdc_diag" {
 
   enabled_log {
     category = "ConnectedClientList"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/redis_enterprise.tf
+++ b/redis_enterprise.tf
@@ -7,10 +7,5 @@ resource "azurerm_monitor_diagnostic_setting" "rdec_diag" {
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/required_providers.tf
+++ b/required_providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/sql.tf
+++ b/sql.tf
@@ -6,129 +6,45 @@ resource "azurerm_monitor_diagnostic_setting" "sql_diag" {
 
   enabled_log {
     category = "AutomaticTuning"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "Blocks"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "DatabaseWaitStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "Deadlocks"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "DevOpsOperationsAudit"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Errors"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "QueryStoreRuntimeStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "QueryStoreWaitStatistics"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   enabled_log {
     category = "SQLInsights"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "SQLSecurityAuditEvents"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "Timeouts"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 
   metric {
     category = "Basic"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "InstanceAndAppAdvanced"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "WorkloadManagement"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }

--- a/storage.tf
+++ b/storage.tf
@@ -8,49 +8,20 @@ resource "azurerm_monitor_diagnostic_setting" "sa_blob_diag" {
 
   enabled_log {
     category = "StorageDelete"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageRead"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageWrite"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "Capacity"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "Transaction"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }
 
@@ -64,21 +35,10 @@ resource "azurerm_monitor_diagnostic_setting" "sa_diag" {
   metric {
     category = "Transaction"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "Capacity"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
 }
 
@@ -91,49 +51,20 @@ resource "azurerm_monitor_diagnostic_setting" "sa_queue_diag" {
 
   enabled_log {
     category = "StorageDelete"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageRead"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageWrite"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "Capacity"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "Transaction"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }
 
@@ -147,49 +78,20 @@ resource "azurerm_monitor_diagnostic_setting" "sa_table_diag" {
 
   enabled_log {
     category = "StorageDelete"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageRead"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageWrite"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "Capacity"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "Transaction"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }
 
@@ -203,48 +105,19 @@ resource "azurerm_monitor_diagnostic_setting" "file_table_diag" {
 
   enabled_log {
     category = "StorageDelete"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageRead"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
   enabled_log {
     category = "StorageWrite"
-
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "Capacity"
-
-
-    retention_policy {
-      days    = 0
-      enabled = false
-    }
   }
   metric {
     category = "Transaction"
     enabled  = false
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/subscription.tf
+++ b/subscription.tf
@@ -8,34 +8,26 @@ resource "azurerm_monitor_diagnostic_setting" "sub_diag" {
   # If you add the retention block, Azure will remove it in the background creating an update with every terraform plan/apply
   enabled_log {
     category = "Administrative"
-
   }
   enabled_log {
     category = "Alert"
-
   }
   enabled_log {
     category = "Autoscale"
-
   }
   enabled_log {
     category = "Policy"
-
   }
   enabled_log {
     category = "Recommendation"
-
   }
   enabled_log {
     category = "ResourceHealth"
-
   }
   enabled_log {
     category = "Security"
-
   }
   enabled_log {
     category = "ServiceHealth"
-
   }
 }

--- a/vnet.tf
+++ b/vnet.tf
@@ -7,10 +7,5 @@ resource "azurerm_monitor_diagnostic_setting" "vnet_diag" {
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }

--- a/webapp.tf
+++ b/webapp.tf
@@ -6,83 +6,38 @@ resource "azurerm_monitor_diagnostic_setting" "webapp_diag" {
 
   enabled_log {
     category = "AppServiceAntivirusScanAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceAppLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceConsoleLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceFileAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceHTTPLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServiceIPSecAuditLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   enabled_log {
     category = "AppServicePlatformLogs"
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      days    = 0
-      enabled = true
-    }
   }
 }


### PR DESCRIPTION
Add "required_providers" block with loose versioning.
Removes deprecated "retention_policy" block as it was leading to **hundreds** of warnings in Terraform: 
- https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy?tabs=portal
- https://stackoverflow.com/questions/77717130/retention-policy-terraform-is-deprecated-inside-azurerm-monitor-diagnostic-setti
- We're not keeping these logs in a storage account, so I opted to remove and not replace it.  The Log Analytics Workspace should have its own retention setting.