### PR TITLE
removing deprecated arguments from avd_hostpool_diag

### DIFF
--- a/avd_hostpool.tf
+++ b/avd_hostpool.tf
@@ -12,13 +12,6 @@ resource "azurerm_monitor_diagnostic_setting" "avd_hostpool_diag" {
   }
   enabled_log {
     category = "Management"
-
-
-    retention_policy {
-      enabled = true
-      days    = 0
-
-    }
   }
   enabled_log {
     category = "Connection"


### PR DESCRIPTION
I removed the deprecated argument from avd_hostpool_diag thats causing errors. Quality of life fix. 