### PR TITLE
fix: license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Coalfire Systems, Inc.
+Copyright (c) 2026 Coalfire Systems, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR updates the LICENSE copyright year from 2023 to 2026.