### PR TITLE
chore: update org-release.yml to v0.2.1

### DIFF
--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -4,6 +4,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: read
 
 on:
   pull_request:
@@ -14,4 +15,5 @@ on:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@v0.1.1
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@v0.2.1
+    secrets: inherit


### PR DESCRIPTION
Updates org-release.yml workflow to use Coalfire-CF/Actions v0.2.1