### PR TITLE
chore(ci): adopt Coalfire-CF/Actions v0.11.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "06:14"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -26,6 +27,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "06:14"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/org-dependabot-auto-merge.yml
+++ b/.github/workflows/org-dependabot-auto-merge.yml
@@ -24,5 +24,5 @@ permissions:
 jobs:
   auto-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
     secrets: inherit

--- a/.github/workflows/org-dependabot.yml
+++ b/.github/workflows/org-dependabot.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   refresh:
-    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
     with:
       head_branch: ${{ github.head_ref || github.ref_name }}  # PR head, or current branch if not a PR
       include_github_actions: "true"

--- a/.github/workflows/org-md-lint.yml
+++ b/.github/workflows/org-md-lint.yml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   check-markdown:
-    uses: Coalfire-CF/Actions/.github/workflows/org-markdown-lint.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-markdown-lint.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3

--- a/.github/workflows/org-release.yml
+++ b/.github/workflows/org-release.yml
@@ -15,5 +15,5 @@ on:
 
 jobs:
   create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
     secrets: inherit

--- a/.github/workflows/org-terraform-docs.yml
+++ b/.github/workflows/org-terraform-docs.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-docs.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3

--- a/.github/workflows/org-terraform-fmt.yml
+++ b/.github/workflows/org-terraform-fmt.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   terraform-docs:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-fmt.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
     with:
       terraform_version: "1.13.3"

--- a/.github/workflows/org-terraform-validate.yml
+++ b/.github/workflows/org-terraform-validate.yml
@@ -6,8 +6,6 @@ permissions:
 
 on:
   pull_request:
-    types:
-      - opened
     paths:
       - "**.tf"
       - "**.tfvars"
@@ -16,8 +14,8 @@ on:
       - "**/terraform/**"
 
 jobs:
-  create-release:
-    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+  terraform-validate:
+    uses: Coalfire-CF/Actions/.github/workflows/org-terraform-validate.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
     with:
       terraform_version: "1.13.3"
     secrets: inherit

--- a/.github/workflows/org-tree-readme.yml
+++ b/.github/workflows/org-tree-readme.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   readme-tree:
-    uses: Coalfire-CF/Actions/.github/workflows/org-tree-readme.yml@72d0360b99f80252dda40f6dfefc252f5a66edb3 # v0.10.0
+    uses: Coalfire-CF/Actions/.github/workflows/org-tree-readme.yml@9451b979c22b3762b3c8a7d4d9493fefaee7edc5 # v0.11.3
     with:
       commit_message: "chore: update README tree"
       exclude_pattern: ".git|node_modules|.github|dist|build"

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ No outputs.
 ### Copyright
 
 Copyright © 2023 Coalfire Systems Inc.
+
 ## Tree
 
 ```text

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ No outputs.
 
 Copyright © 2023 Coalfire Systems Inc.
 ## Tree
+
 ```text
 .
 |-- CHANGELOG.md


### PR DESCRIPTION
Adopts `Coalfire-CF/Actions` **v0.11.3** (`9451b979c22b3762b3c8a7d4d9493fefaee7edc5`) across this repo's reusable-workflow callers.

- **Re-pin** every `org-*.yml` caller to the v0.11.3 release SHA with an adjacent `# v0.11.3` comment (RFC-0008 SHA-preferred pinning).
- **dependabot.yml**: deterministic per-repo stagger `time:` + homogeneous `org-actions`/`third-party` groups (v0.11.3 generator shape) where missing.
- **org-terraform-validate.yml**: drop the `types: [opened]` PR filter (run on all PR events) and rename the `create-release` job to `terraform-validate` (skipped when a ruleset/branch-protection required-check still references the old name).
- Inherits the issue #149 actor-gated push-back behavior (tree/terraform-docs pushes suppressed on read-only Dependabot-actor runs; drift stays visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BMzQpyubxj9jWW7MXyk75S